### PR TITLE
add crossOrigin request to img to support cors

### DIFF
--- a/blur.jsx
+++ b/blur.jsx
@@ -34,6 +34,7 @@ var ReactBlur = React.createClass({
 
         var ctx = Blur.canvas.getContext('2d');
         Blur.img = new Image;
+        Blur.img.crossOrigin = "Anonymous";
         Blur.img.onload = function(){
             stackBlurImage( Blur.img, Blur.canvas, blurRadius, Blur.width, Blur.height)
         };


### PR DESCRIPTION
We used your plugin and we have a problem loading images from a domain owner by us but diferent from the frontend application because images with diferent urls through a canvas error "tainted canvas":
https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image
We fixed that adding the solution on previous mozilla developers page.