### PR TITLE
Remove the onerror listener in callback.

### DIFF
--- a/src/blur.jsx
+++ b/src/blur.jsx
@@ -77,7 +77,8 @@ export default class ReactBlur extends React.Component {
       props.onLoadFunction(event);
     };
     this.img.onerror     = (event) => {
-      this.img.src = '';
+      this.img.onerror = undefined; // Remove the onerror listener. Preventing recursive calls caused by setting this.img.src to a falsey value
+      this.img.src     = '';
       props.onLoadFunction(event);
     };
     this.img.src         = props.img;


### PR DESCRIPTION
Prevents recursive calls caused by setting `this.img.src` to a falsey value. eg. an empty string.