### PR TITLE
Guard against unmounting before image loads

### DIFF
--- a/src/blur.jsx
+++ b/src/blur.jsx
@@ -98,14 +98,16 @@ class ReactBlur extends React.PureComponent {
     this.img.crossOrigin = 'Anonymous';
 
     this.img.onload = event => {
-      stackBlurImage(
-        this.img,
-        this.canvas,
-        this.getCurrentBlur(),
-        this.width,
-        this.height
-      );
-      this.props.onLoadFunction(event);
+      if (this.img && this.canvas) {
+        stackBlurImage(
+          this.img,
+          this.canvas,
+          this.getCurrentBlur(),
+          this.width,
+          this.height
+        );
+        this.props.onLoadFunction(event);
+      }
     };
 
     this.img.onerror = event => {


### PR DESCRIPTION
If the component unmounts before the image is loaded, the refs will be `null`.
This is because React calls the ref callbacks with `null` as the component
unmount.

We use this component in a virtualized list using [React Virtualize](https://github.com/bvaughn/react-virtualized). You can scroll through the list really fast, meaning that we sometimes mount and unmount components in an instant.