### PR TITLE
hot fix Failed to execute 'getImageData' on 'CanvasRenderingContext2D…

### DIFF
--- a/lib/StackBlur.js
+++ b/lib/StackBlur.js
@@ -39,6 +39,7 @@ var shg_table = [
 ];
 
 function stackBlurImage(img, canvas, radius, w, h) {
+    if (!w || !h) return;
     var nw = img.naturalWidth;
     var nh = img.naturalHeight;
 


### PR DESCRIPTION
fix error:
"Failed to execute 'getImageData' on 'CanvasRenderingContext2D': The source width is 0."
when canvas.width or canvas.height = 0